### PR TITLE
cssnano wrongly changes z-index values when building

### DIFF
--- a/generators/app/templates/gulpfile.babel.js
+++ b/generators/app/templates/gulpfile.babel.js
@@ -95,7 +95,7 @@ gulp.task('html', ['styles', 'scripts'], () => {
   <% } %>
   .pipe($.if('*.js', $.uglify()))
     .pipe($.if('*.css', $.cssSandbox('#' + options.root)))
-    .pipe($.if('*.css', $.cssnano({z-index: false})))
+    .pipe($.if('*.css', $.cssnano({zindex: false})))
     // convert relative urls to absolute
     .pipe($.if('*.html', $.cdnizer({
       defaultCDNBase: options.dist.host,

--- a/generators/app/templates/gulpfile.babel.js
+++ b/generators/app/templates/gulpfile.babel.js
@@ -95,7 +95,7 @@ gulp.task('html', ['styles', 'scripts'], () => {
   <% } %>
   .pipe($.if('*.js', $.uglify()))
     .pipe($.if('*.css', $.cssSandbox('#' + options.root)))
-    .pipe($.if('*.css', $.cssnano()))
+    .pipe($.if('*.css', $.cssnano({z-index: false})))
     // convert relative urls to absolute
     .pipe($.if('*.html', $.cdnizer({
       defaultCDNBase: options.dist.host,


### PR DESCRIPTION
See issue reported here: https://github.com/ben-eb/gulp-cssnano/issues/8
Pass zindex:false option to cssnano to work around the problem.