### PR TITLE
Fix semver-regex vulnerability

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -556,4 +556,10 @@ module.exports = class extends yeoman {
       yarn: false
     });
   }
+
+  end() {
+    // Run npm install again to resolve dependencies.
+    this.log('\n' + chalk.green('(generator-addin) Resolving dependencies...'));
+    this.spawnCommand('npm', ['install']);
+  }
 };

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -49,8 +49,8 @@
     "webpack": "^5.59.1",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.3.1",
-    "webpack-fix-style-only-entries": "^0.6.1",
-    "webpack-merge": "^5.8.0"
+    "webpack-merge": "^5.8.0",
+    "webpack-remove-empty-scripts": "^0.7.1"
   },
   "eslintConfig": {
     "parserOptions": {

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -4,12 +4,16 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
     <% if(!isButton && !isDriveAddin) {%>"build:template": "node ./utils/templateBuilder.js",
       "template": "start-server-and-test serve http://localhost:9000 build:template",<% } %>
     "build": "webpack --mode production --config webpack.production.js",
     "serve": "webpack serve --mode development --config webpack.development.js",
     "test": "start-server-and-test serve http://localhost:9000 mocha",
     "mocha": "mocha test/**/*.js"
+  },
+  "resolutions": {
+    "semver-regex": "4.0.2"
   },
   "keywords": [],
   "author": "",
@@ -37,6 +41,7 @@
     "mocha": "^9.1.3",
     "puppeteer": "^10.4.0",
     "regenerator-runtime": "^0.13.9",
+    "semver-regex": "^4.0.2",
     "start-server-and-test": "<=1.14.0",
     "style-loader": "^3.3.1",
     "svg-inline-loader": "^0.8.2",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -36,7 +36,7 @@
     "imagemin-gifsicle": "^7.0.0",
     "imagemin-mozjpeg": "^9.0.0",
     "imagemin-pngquant": "^9.0.2",
-    "imagemin-svgo": "^10.0.0",
+    "imagemin-svgo": "^9.0.0",
     "mini-css-extract-plugin": "^2.4.3",
     "mocha": "^9.1.3",
     "puppeteer": "^10.4.0",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -13,7 +13,7 @@
     "mocha": "mocha test/**/*.js"
   },
   "resolutions": {
-    "semver-regex": "4.0.2"
+    "semver-regex": "4.0.1"
   },
   "keywords": [],
   "author": "",
@@ -41,7 +41,7 @@
     "mocha": "^9.1.3",
     "puppeteer": "^10.4.0",
     "regenerator-runtime": "^0.13.9",
-    "semver-regex": "^4.0.2",
+    "semver-regex": "^4.0.1",
     "start-server-and-test": "<=1.14.0",
     "style-loader": "^3.3.1",
     "svg-inline-loader": "^0.8.2",

--- a/generators/app/templates/webpack.production.js
+++ b/generators/app/templates/webpack.production.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const ImageMinimizerPlugin = require('image-minimizer-webpack-plugin');
@@ -96,7 +96,7 @@ module.exports = merge(common, {
             exclude: ['/node_modules/', '/\.dev/'],
             formatter: 'stylish'
         }),
-        new FixStyleOnlyEntriesPlugin(),
+        new RemoveEmptyScriptsPlugin(),
         new ImageMinimizerPlugin({
             exclude: /dev/,
             test: /\.(jpe?g|png|gif|svg)$/,


### PR DESCRIPTION
Force npm resolution for semver-regex@4.0.2.

Other changes:
- replaced webpack-fix-style-only-entries for webpack 5 compatibility.
- downgrade imagemin-svgo for compatibility with image-minimizer-webpack-plugin.