### PR TITLE
Change app.less to main.css

### DIFF
--- a/generators/app/templates/src/.dev/login/loginTemplate.js
+++ b/generators/app/templates/src/.dev/login/loginTemplate.js
@@ -4,9 +4,9 @@ import xIcon from '../images/close-round.svg';
 import addinIcon from '../../app/images/icon.svg';
 let loginExample = `
 <% if (isDriveAddin) {%>
-    <link rel="stylesheet" href="https://mypreview.geotab.com/drive/app/css/app.less">
+    <link rel="stylesheet" href="https://mypreview.geotab.com/drive/app/css/main.css">
 <% } else { %>
-    <link rel="stylesheet" href="https://mypreview.geotab.com/geotab/checkmate/app.less?skin=my_geotab">
+    <link rel="stylesheet" href="https://mypreview.geotab.com/geotab/checkmate/main.css?skin=my_geotab">
 <% } %>
 <style>
     body {

--- a/generators/app/templates/src/.dev/styles/styleGuideMyGeotab.html
+++ b/generators/app/templates/src/.dev/styles/styleGuideMyGeotab.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<title>Public Style</title>
-	<link rel="stylesheet" href="https://my.geotab.com/geotab/checkmate/app.less?skin=my_geotab">
+	<link rel="stylesheet" href="https://my.geotab.com/geotab/checkmate/main.css?skin=my_geotab">
 	<link rel="stylesheet" href="styleGuide.css">
 </head>
 <body>


### PR DESCRIPTION
`app.less` has not been working approximately since 7.0+ possibly as a side effect from a change to how we compile less files.  This can easily be resolved by referring to `main.css` instead.  See the original issue for more details.