### PR TITLE
SOLENG-40909 image references corrupted on build

### DIFF
--- a/CHANGLONG.md
+++ b/CHANGLONG.md
@@ -1,0 +1,5 @@
+# March 6, 2023 - SOLENG-40909
+
+- Initial Issue: images references kept getting corrupted on build. image file names did not match their respective reference on the HTML file.
+- Investigation: the issue seemed to occur due to something related to the image minimizer, as I noticed that removing the minimizers resolved the issue.
+- Fix: setting the file name to match the original name instead of letting webpack generate the hash/filename.

--- a/generators/app/templates/webpack.production.js
+++ b/generators/app/templates/webpack.production.js
@@ -21,9 +21,9 @@ const transform = function (content, path) {
     let host = config.dev.dist.host;
     let len = config.items.length;
     // Appending the host to all item's url and icon
-    for(let i=0;i<len;i++){
+    for (let i = 0; i < len; i++) {
         config.items[i].url = host + config.items[i].url;
-        config.items[i].icon = host + config.items[i].icon; 
+        config.items[i].icon = host + config.items[i].icon;
     }
 
     delete config['dev'];
@@ -111,7 +111,7 @@ module.exports = merge(common, {
                             plugins: [
                                 {
                                     name: "cleanupIDs",
-                                    active: false 
+                                    active: false
                                 }
                             ]
                         }
@@ -125,9 +125,10 @@ module.exports = merge(common, {
                 { from: './src/app/config.json', transform: transform },
                 { from: './src/app/translations/', to: 'translations/' }
             ]
-        }) 
+        })
     ],
     output: {
-        publicPath: config.dev.dist.host
+        publicPath: config.dev.dist.host,
+        assetModuleFilename: '[name][ext][query]'
     }
 });


### PR DESCRIPTION
This fixes the image referencing issue of the addin generator by setting the image filename to match it's original name instead of letting webpack set the hash/filename.